### PR TITLE
Boolean Bug Fixes and Warning Removes

### DIFF
--- a/QBTracker/QubitSDK/Extensions/JSONQuibitSerialization.swift
+++ b/QBTracker/QubitSDK/Extensions/JSONQuibitSerialization.swift
@@ -163,7 +163,12 @@ private struct JSONWriter {
         case let str as String:
             try serializeString(str)
         case let number as NSNumber:
-            try serializeNumber(number)
+            if isBoolNumber(num: number) {
+                serializeBool(number)
+            }
+            else {
+                try serializeNumber(number)
+            }
         case let boolValue as Bool:
             serializeBool(boolValue)
         case let array as Array<Any>:
@@ -177,6 +182,13 @@ private struct JSONWriter {
         default:
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.propertyListReadCorrupt.rawValue, userInfo: ["NSDebugDescription" : "Invalid object cannot be serialized"])
         }
+    }
+    
+    func isBoolNumber(num:NSNumber) -> Bool
+    {
+        let boolID = CFBooleanGetTypeID() // the type ID of CFBoolean
+        let numID = CFGetTypeID(num) // the type ID of num
+        return numID == boolID
     }
     
     func serializeString(_ str: String) throws {
@@ -216,6 +228,10 @@ private struct JSONWriter {
         case false:
             writer("false")
         }
+    }
+    
+    func serializeBool(_ number: NSNumber) {
+        number == 1 ? writer("true") : writer("false")
     }
     
     mutating func serializeNumber(_ num: NSNumber) throws {
@@ -572,9 +588,9 @@ private struct JSONReader {
                 
                 let startPointer = buffer.baseAddress!
                 let intEndPointer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 1)
-                defer { intEndPointer.deallocate(capacity: 1) }
+                defer { intEndPointer.deallocate() }
                 let doubleEndPointer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 1)
-                defer { doubleEndPointer.deallocate(capacity: 1) }
+                defer { doubleEndPointer.deallocate() }
                 
                 let intResult = strtol(startPointer, intEndPointer, 10)
                 let intDistance = startPointer.distance(to: intEndPointer[0]!)

--- a/QBTracker/QubitSDK/Extensions/String+Extensions.swift
+++ b/QBTracker/QubitSDK/Extensions/String+Extensions.swift
@@ -26,7 +26,7 @@ extension String {
             hash.appendFormat("%02x", result[index])
         }
 
-        result.deallocate(capacity: digestLen)
+        result.deallocate()
 
         return String(format: hash as String)
     }

--- a/QBTracker/QubitSDK/QubitSDK.swift
+++ b/QBTracker/QubitSDK/QubitSDK.swift
@@ -26,7 +26,9 @@ public class QubitSDK: NSObject {
     ///   - logLevel: QBLogLevel, default = .disabled
     @objc(startWithTrackingId:logLevel:)
     public class func start(withTrackingId id: String, logLevel: QBLogLevel = QBLogLevel.disabled) {
-        QubitSDK.handleException()
+        if logLevel != .disabled {
+            QubitSDK.handleException()
+        }
         trackingId = id
         QBDispatchQueueService.runAsync(type: .qubit) { QBTracker.shared.start(withTrackingId: id, logLevel: logLevel) }
     }

--- a/QBTracker/SwiftTestApp/AppDelegate.swift
+++ b/QBTracker/SwiftTestApp/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import QubitSDK
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -14,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        QubitSDK.start(withTrackingId: "miquido", logLevel: .verbose)
         return true
     }
 	

--- a/QBTracker/SwiftTestApp/ViewController.swift
+++ b/QBTracker/SwiftTestApp/ViewController.swift
@@ -15,7 +15,6 @@ class ViewController: UIViewController {
     @IBOutlet weak var eventsLabel: UILabel!
     
     override func viewDidLoad() {
-        QubitSDK.start(withTrackingId: "miquido", logLevel: .verbose)
         super.viewDidLoad()
     }
     


### PR DESCRIPTION
Fixed:
While sending an event, it changes boolean fields to Int values 0 and 1
HandleException is working even if log level is disabled
SDK prints warnings

Enhancement:
Starting SDK in the test app moved to AppDelegate