### PR TITLE
[LENS-1722] Adds info on the privacy manifest

### DIFF
--- a/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
+++ b/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
@@ -26,8 +26,8 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
 		<dict>

--- a/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
+++ b/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
@@ -6,18 +6,6 @@
 	<array>
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeDeviceID</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<true/>
@@ -78,6 +66,18 @@
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
 				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ This repository contains the privacy manifest, which details the data collected 
 > 
 > **Other Data Types** here represent `system version` and `system name` of the devices that use the SDK.
 
-The SDK doesn't collect any sensitive data, such as payment information or passwords.
-It only has access to the data that the app has access to.
+The SDK collects metadata automatically, but it also has access to any data that you chose to implement. 
+This way, the SDK has access to all the data that you put into the `QubitSDK.sendEvent()` calls. 
 This level of access is reflected in the `NSPrivacyAccessedAPITypeReasons` key via the `CA92.1` value.
+
+> **IMPORTANT**
+>
+> If you choose to include additional data to sent events, you must update the privacy manifest accordingly. 
 
 Examine the file for more details: https://github.com/qubitdigital/qubit-sdk-ios/blob/master/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This level of access is reflected in the `NSPrivacyAccessedAPITypeReasons` key v
 
 Examine the file for more details: https://github.com/qubitdigital/qubit-sdk-ios/blob/master/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
 
-See the Apple documentation: [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
+For more general information about privacy manifest files, see the Apple documentation: [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
 
 ### Getting started
 To make use of this SDK, please contact your Qubit Customer Success representative.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This repository contains the privacy manifest, which details the data collected 
 > 
 > **Other Data Types** here represent `system version` and `system name` of the devices that use the SDK.
 
-The SDK collects metadata automatically, but it also has access to any data that you chose to implement. 
-This way, the SDK has access to all the data that you put into the `QubitSDK.sendEvent()` calls. 
+The SDK collects metadata about the device (such as the application version and iOS version) automatically. 
+It also collects any additional data that you chose to implement, which means data passed through `QubitSDK.sendEvent()` calls.
 This level of access is reflected in the `NSPrivacyAccessedAPITypeReasons` key via the `CA92.1` value.
 
 > **IMPORTANT**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This level of access is reflected in the `NSPrivacyAccessedAPITypeReasons` key v
 
 > **IMPORTANT**
 >
-> If you choose to include additional data to sent events, you must update the privacy manifest accordingly. 
+> If you choose to include additional data in sent events, you must update the privacy manifest accordingly. 
 
 Examine the file for more details: https://github.com/qubitdigital/qubit-sdk-ios/blob/master/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@ This SDK enables comprehensive event tracking and Qubit experience delivery from
 ### Compatibility
 This release is compatible with Xcode 12 & iOS14, and supports Swift & Objective-C.
 
+### Privacy
+
+This repository contains the privacy manifest, which details the data collected by the SDK:
+
+| Data type               | What it's used for                       |
+|-------------------------|------------------------------------------|
+| **Device ID**           | Product personalization and analytics    |
+| **Product Interaction** | Product personalization and analytics    |
+| **Email Address**       | Product personalization and analytics    |
+| **User ID**             | Product personalization and analytics    |
+| **Coarse Location**     | Product personalization and analytics    |
+| **Other Data Types**    | Analytics                                |
+
+> **Note**
+> 
+> **Other Data Types** here represent `system version` and `system name` of the devices that use the SDK.
+
+The SDK doesn't collect any sensitive data, such as payment information or passwords.
+It only has access to the data that the app has access to.
+This level of access is reflected in the `NSPrivacyAccessedAPITypeReasons` key via the `CA92.1` value.
+
+Examine the file for more details: https://github.com/qubitdigital/qubit-sdk-ios/blob/master/QBTracker/QubitSDK/PrivacyInfo.xcprivacy
+
+See the Apple documentation: [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
+
 ### Getting started
 To make use of this SDK, please contact your Qubit Customer Success representative.
 
@@ -47,9 +72,6 @@ Further release notes are available in the [GitHub release notes](https://github
 | 1 | Swift Package Manager | Swift | GitHub |
 | 2 | CocoaPods | Swift & Objective-C | CocoaPods.org & GitHub |
 | 3 | XCFramework | Swift & Objective-C | GitHub |
-
-
-
 
 Further details on installation options are below.
 


### PR DESCRIPTION
JIRA link: https://coveord.atlassian.net/browse/LENS-1722

This PR adds info about the privacy manifest (the same text as in https://github.com/coveo/doc_jekyll-public-site/pull/11269).

I've also taken the liberty to slightly update the manifest itself: 

* I moved `OtherDataTypes` to the bottom. 
* I made sure that `TypePurposes` are enlisted in the same order for every data type.

⚠️ GH shows the diff in a quirky way, the local diff is way more readable:

![image](https://github.com/qubitdigital/qubit-sdk-ios/assets/92988368/132015bc-fc0d-4d7a-84d0-5af398d66b83)

![image](https://github.com/qubitdigital/qubit-sdk-ios/assets/92988368/ff4da3bc-5ffc-432b-a1a9-07e6b80b8136)
